### PR TITLE
build: set better timeout

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,7 @@ on:
 jobs:
     check:
         runs-on: ubuntu-latest
+        timeout-minutes: 60
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-java@v2
@@ -19,6 +20,7 @@ jobs:
     publish:
         needs: check
         runs-on: ubuntu-latest
+        timeout-minutes: 60
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-java@v2
@@ -40,6 +42,7 @@ jobs:
     release:
         needs: publish
         runs-on: ubuntu-latest
+        timeout-minutes: 60
         steps:
             - uses: actions/checkout@v2
             - uses: actions/create-release@v1


### PR DESCRIPTION
Set missing timeouts to 60 to avoid using the default of 6 hours.

See https://github.com/Doist/Issues/issues/5259